### PR TITLE
Fix MPI job launches and stdout capture

### DIFF
--- a/lessons/01_Introduction/intro_mpi.ipynb
+++ b/lessons/01_Introduction/intro_mpi.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# Are you using a special reservation for a workshop?\n",
     "# If so, set it here:\n",
-    "nersc_reservation = None\n",
+    "nersc_reservation = \"toast2\"\n",
     "\n",
     "# Load common tools for all lessons\n",
     "import sys\n",
@@ -25,12 +25,10 @@
     "from lesson_tools import (\n",
     "    check_nersc\n",
     ")\n",
-    "nersc_host, nersc_repo = check_nersc(reservation=nersc_reservation)\n",
-    "if nersc_host is not None:\n",
-    "    %reload_ext slurm_magic\n",
+    "nersc_host, nersc_repo, nersc_resv = check_nersc(reservation=nersc_reservation)\n",
     "\n",
     "# Capture C++ output in the jupyter cells\n",
-    "%load_ext wurlitzer"
+    "%reload_ext wurlitzer"
    ]
   },
   {
@@ -120,12 +118,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import subprocess as sp\n",
+    "\n",
+    "command = \"python intro_mpi.py\"\n",
+    "runstr = None\n",
+    "\n",
     "if nersc_host is not None:\n",
-    "    %srun -N 1 -C haswell -n 32 -c 2 --cpu_bind=cores -t 00:03:00 python intro_mpi.py >intro_mpi.log 2>&1\n",
+    "    runstr = \"srun -N 1 -C haswell -n 32 -c 2 --cpu_bind=cores -t 00:03:00\"\n",
+    "    if nersc_resv is not None:\n",
+    "        runstr = \"{} --reservation {}\".format(runstr, nersc_resv)\n",
     "else:\n",
     "    # Just use mpirun\n",
-    "    import subprocess as sp\n",
-    "    sp.check_call(\"mpirun -np 4 python intro_mpi.py >intro_mpi.log 2>&1\", shell=True)"
+    "    runstr = \"mpirun -np 4\"\n",
+    "\n",
+    "runcom = \"{} {}\".format(runstr, command)\n",
+    "print(runcom, flush=True)\n",
+    "sp.check_call(runcom, stderr=sp.STDOUT, shell=True)\n"
    ]
   },
   {

--- a/lessons/02_Simulated_Scan_Strategies/simscan_ground.ipynb
+++ b/lessons/02_Simulated_Scan_Strategies/simscan_ground.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# Are you using a special reservation for a workshop?\n",
     "# If so, set it here:\n",
-    "nersc_reservation = None\n",
+    "nersc_reservation = \"toast3\"\n",
     "\n",
     "# Load common tools for all lessons\n",
     "import sys\n",
@@ -33,9 +33,10 @@
     "    check_nersc,\n",
     "    fake_focalplane\n",
     ")\n",
-    "nersc_host, nersc_repo = check_nersc(reservation=nersc_reservation)\n",
-    "if nersc_host is not None:\n",
-    "    %reload_ext slurm_magic"
+    "nersc_host, nersc_repo, nersc_resv = check_nersc(reservation=nersc_reservation)\n",
+    "\n",
+    "# Capture C++ output in the jupyter cells\n",
+    "%reload_ext wurlitzer"
    ]
   },
   {
@@ -316,12 +317,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if nersc_host is None:\n",
-    "    # Outside of NERSC, we'll assume that MPI is available\n",
-    "    ! toast_ground_sim.py @bin_schedule.par\n",
+    "import subprocess as sp\n",
+    "\n",
+    "command = \"toast_ground_sim.py @bin_schedule.par\"\n",
+    "runstr = None\n",
+    "\n",
+    "if nersc_host is not None:\n",
+    "    runstr = \"srun -N 1 -C haswell -n 32 -c 2 --cpu_bind=cores -t 00:05:00\"\n",
+    "    if nersc_resv is not None:\n",
+    "        runstr = \"{} --reservation {}\".format(runstr, nersc_resv)\n",
     "else:\n",
-    "    # Submit the job to a compute node\n",
-    "    %srun -N 1 -C knl -n 32 -c 2 --cpu_bind=cores -t 00:05:00 toast_ground_sim.py @bin_schedule.par"
+    "    # Just use mpirun\n",
+    "    runstr = \"mpirun -np 4\"\n",
+    "\n",
+    "runcom = \"{} {}\".format(runstr, command)\n",
+    "print(runcom, flush=True)\n",
+    "sp.check_call(runcom, stderr=sp.STDOUT, shell=True)\n"
    ]
   },
   {
@@ -553,12 +564,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if nersc_host is None:\n",
-    "    # Outside of NERSC, we'll assume that MPI is available\n",
-    "    ! toast_ground_sim.py @bin_schedule.par\n",
+    "command = \"toast_ground_sim.py @bin_schedule.par --schedule pole_schedule.txt --out out_pole\"\n",
+    "runstr = None\n",
+    "\n",
+    "if nersc_host is not None:\n",
+    "    runstr = \"srun -N 1 -C haswell -n 32 -c 2 --cpu_bind=cores -t 00:05:00\"\n",
+    "    if nersc_resv is not None:\n",
+    "        runstr = \"{} --reservation {}\".format(runstr, nersc_resv)\n",
     "else:\n",
-    "    # Submit the job to a compute node\n",
-    "    %srun -N 1 -C knl -n 32 -c 2 --cpu_bind=cores -t 00:05:00 toast_ground_sim.py @bin_schedule.par --schedule pole_schedule.txt --out out_pole"
+    "    # Just use mpirun\n",
+    "    runstr = \"mpirun -np 4\"\n",
+    "\n",
+    "runcom = \"{} {}\".format(runstr, command)\n",
+    "print(runcom, flush=True)\n",
+    "sp.check_call(runcom, stderr=sp.STDOUT, shell=True)\n"
    ]
   },
   {

--- a/lessons/02_Simulated_Scan_Strategies/simscan_satellite_mpi.ipynb
+++ b/lessons/02_Simulated_Scan_Strategies/simscan_satellite_mpi.ipynb
@@ -15,7 +15,7 @@
    "source": [
     "# Are you using a special reservation for a workshop?\n",
     "# If so, set it here:\n",
-    "nersc_reservation = None\n",
+    "nersc_reservation = \"toast2\"\n",
     "\n",
     "# Load common tools for all lessons\n",
     "import sys\n",
@@ -23,9 +23,10 @@
     "from lesson_tools import (\n",
     "    check_nersc,\n",
     ")\n",
-    "nersc_host, nersc_repo = check_nersc(reservation=nersc_reservation)\n",
-    "if nersc_host is not None:\n",
-    "    %reload_ext slurm_magic"
+    "nersc_host, nersc_repo, nersc_resv = check_nersc(reservation=nersc_reservation)\n",
+    "\n",
+    "# Capture C++ output in the jupyter cells\n",
+    "%reload_ext wurlitzer\n"
    ]
   },
   {
@@ -62,13 +63,13 @@
     ")\n",
     "\n",
     "env = toast.Environment.get()\n",
-    "env.set_threads(2)\n",
-    "print(env)\n",
     "\n",
     "# We have many small observations, so we should use a small\n",
     "# group size.  Here we choose a group size of one process.\n",
     "\n",
     "comm = toast.Comm(world=MPI.COMM_WORLD, groupsize=1)\n",
+    "if comm.world_rank == 0:\n",
+    "    print(env)\n",
     "\n",
     "# Create our fake focalplane\n",
     "\n",
@@ -189,12 +190,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import subprocess as sp\n",
+    "\n",
+    "command = \"python simscan_satellite_mpi.py\"\n",
+    "runstr = None\n",
+    "\n",
     "if nersc_host is not None:\n",
-    "    %srun -N 1 -C haswell -n 32 -c 2 --cpu_bind=cores -t 00:05:00 python simscan_satellite_mpi.py >simscan_satellite_mpi.log 2>&1\n",
+    "    runstr = \"export OMP_NUM_THREADS=4; srun -N 2 -C haswell -n 32 -c 4 --cpu_bind=cores -t 00:05:00\"\n",
+    "    if nersc_resv is not None:\n",
+    "        runstr = \"{} --reservation {}\".format(runstr, nersc_resv)\n",
     "else:\n",
     "    # Just use mpirun\n",
-    "    import subprocess as sp\n",
-    "    sp.check_call(\"mpirun -np 4 python simscan_satellite_mpi.py >simscan_satellite_mpi.log 2>&1\", shell=True)"
+    "    runstr = \"mpirun -np 4\"\n",
+    "\n",
+    "runcom = \"{} {}\".format(runstr, command)\n",
+    "print(runcom, flush=True)\n",
+    "sp.check_call(runcom, stderr=sp.STDOUT, shell=True)\n"
    ]
   },
   {

--- a/lessons/03_Simulated_Sky_Signal/simsky_mapdomain.ipynb
+++ b/lessons/03_Simulated_Sky_Signal/simsky_mapdomain.ipynb
@@ -48,9 +48,11 @@
     "import sys\n",
     "sys.path.insert(0, \"..\")\n",
     "from lesson_tools import (\n",
-    "    check_nersc,\n",
     "    fake_focalplane\n",
-    ")"
+    ")\n",
+    "\n",
+    "# Capture C++ output in the jupyter cells\n",
+    "%reload_ext wurlitzer"
    ]
   },
   {

--- a/lessons/03_Simulated_Sky_Signal/simsky_timedomain.ipynb
+++ b/lessons/03_Simulated_Sky_Signal/simsky_timedomain.ipynb
@@ -21,9 +21,11 @@
     "import sys\n",
     "sys.path.insert(0, \"..\")\n",
     "from lesson_tools import (\n",
-    "    check_nersc,\n",
     "    fake_focalplane\n",
-    ")"
+    ")\n",
+    "\n",
+    "# Capture C++ output in the jupyter cells\n",
+    "%reload_ext wurlitzer"
    ]
   },
   {

--- a/lessons/04_Simulated_Instrument_Signal/siminst.ipynb
+++ b/lessons/04_Simulated_Instrument_Signal/siminst.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "# Are you using a special reservation for a workshop?\n",
     "# If so, set it here:\n",
-    "nersc_reservation = None\n",
+    "nersc_reservation = \"toast3\"\n",
     "\n",
     "# Load common tools for all lessons\n",
     "import sys\n",
@@ -32,9 +32,10 @@
     "    check_nersc,\n",
     "    fake_focalplane\n",
     ")\n",
-    "nersc_host, nersc_repo = check_nersc(reservation=nersc_reservation)\n",
-    "if nersc_host is not None:\n",
-    "    %reload_ext slurm_magic"
+    "nersc_host, nersc_repo, nersc_resv = check_nersc(reservation=nersc_reservation)\n",
+    "\n",
+    "# Capture C++ output in the jupyter cells\n",
+    "%reload_ext wurlitzer\n"
    ]
   },
   {

--- a/lessons/05_Considerations_for_Real_Data/realdata.ipynb
+++ b/lessons/05_Considerations_for_Real_Data/realdata.ipynb
@@ -17,7 +17,7 @@
    "source": [
     "# Are you using a special reservation for a workshop?\n",
     "# If so, set it here:\n",
-    "nersc_reservation = None\n",
+    "nersc_reservation = \"toast3\"\n",
     "\n",
     "# Load common tools for all lessons\n",
     "import sys\n",
@@ -26,9 +26,10 @@
     "    check_nersc,\n",
     "    fake_focalplane\n",
     ")\n",
-    "nersc_host, nersc_repo = check_nersc(reservation=nersc_reservation)\n",
-    "if nersc_host is not None:\n",
-    "    %reload_ext slurm_magic"
+    "nersc_host, nersc_repo, nersc_resv = check_nersc(reservation=nersc_reservation)\n",
+    "\n",
+    "# Capture C++ output in the jupyter cells\n",
+    "%reload_ext wurlitzer\n"
    ]
   },
   {
@@ -58,8 +59,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# if nersc_host is not None:\n",
-    "#    %srun -N 1 -C knl -n 32 -c 2 --cpu_bind=cores -t 00:03:00 python realdata.py"
+    "import subprocess as sp\n",
+    "\n",
+    "command = \"python realdata.py\"\n",
+    "runstr = None\n",
+    "\n",
+    "if nersc_host is not None:\n",
+    "    runstr = \"srun -N 1 -C haswell -n 32 -c 2 --cpu_bind=cores -t 00:03:00\"\n",
+    "    if nersc_resv is not None:\n",
+    "        runstr = \"{} --reservation {}\".format(runstr, nersc_resv)\n",
+    "else:\n",
+    "    # Just use mpirun\n",
+    "    runstr = \"mpirun -np 4\"\n",
+    "\n",
+    "runcom = \"{} {}\".format(runstr, command)\n",
+    "print(runcom, flush=True)\n",
+    "sp.check_call(runcom, stderr=sp.STDOUT, shell=True)\n"
    ]
   }
  ],

--- a/lessons/06_Map_Making/mapmaking.ipynb
+++ b/lessons/06_Map_Making/mapmaking.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "# Are you using a special reservation for a workshop?\n",
     "# If so, set it here:\n",
-    "nersc_reservation = None\n",
+    "nersc_reservation = \"toast3\"\n",
     "\n",
     "# Load common tools for all lessons\n",
     "import sys\n",
@@ -28,9 +28,10 @@
     "    check_nersc,\n",
     "    fake_focalplane\n",
     ")\n",
-    "nersc_host, nersc_repo = check_nersc(reservation=nersc_reservation)\n",
-    "if nersc_host is not None:\n",
-    "    %reload_ext slurm_magic"
+    "nersc_host, nersc_repo, nersc_resv = check_nersc(reservation=nersc_reservation)\n",
+    "\n",
+    "# Capture C++ output in the jupyter cells\n",
+    "%reload_ext wurlitzer\n"
    ]
   },
   {

--- a/lessons/07_Pipelines/pipelines.ipynb
+++ b/lessons/07_Pipelines/pipelines.ipynb
@@ -21,7 +21,7 @@
    "source": [
     "# Are you using a special reservation for a workshop?\n",
     "# If so, set it here:\n",
-    "nersc_reservation = None\n",
+    "nersc_reservation = \"toast3\"\n",
     "\n",
     "# Load common tools for all lessons\n",
     "import sys\n",
@@ -30,9 +30,10 @@
     "    check_nersc,\n",
     "    fake_focalplane\n",
     ")\n",
-    "nersc_host, nersc_repo = check_nersc(reservation=nersc_reservation)\n",
-    "if nersc_host is not None:\n",
-    "    %reload_ext slurm_magic"
+    "nersc_host, nersc_repo, nersc_resv = check_nersc(reservation=nersc_reservation)\n",
+    "\n",
+    "# Capture C++ output in the jupyter cells\n",
+    "%reload_ext wurlitzer\n"
    ]
   },
   {
@@ -671,7 +672,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Finally, instead of submitting the job with SLURM magic, we write an actual script and submit it."
+    "Finally, instead of submitting the job interactively with srun, we write an actual script and submit it."
    ]
   },
   {


### PR DESCRIPTION
This modifies all notebooks to check for NERSC reservations and submit jobs using srun with subprocess calls.  No slurm magic extension is needed.  Also add the wurlitzer extension which captures compiled extension output into the cells.  All notebooks run.