### PR TITLE
intro.ipynb: fix duplicated plotting

### DIFF
--- a/lessons/01_Introduction/intro.ipynb
+++ b/lessons/01_Introduction/intro.ipynb
@@ -93,7 +93,7 @@
     "\n",
     "toast.tod.plot_focalplane(\n",
     "    detquat, 4.0, 4.0, None, fwhm=detfwhm, polcolor=detpolcol, labels=detlabels\n",
-    ")"
+    ");"
    ]
   },
   {


### PR DESCRIPTION
Because of hpc4cmb/toast@ec05a81, the function now returns the fig, and the Jupyter inline magic will first show the plot automatically, then render the unassigned returned object, and since the returned object is the plot itself, it will render it again.

The fix is just to add `;` in the end of line to effectively tell Jupyter to discard the unassigned returned object.